### PR TITLE
Update result popup link

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,9 +301,9 @@
   <div class="popup-box">
     <button class="close-popup" aria-label="Close">&times;</button>
     <h3>Results Submitted</h3>
-    <p>You can now visit the results spreadsheet to record your work.</p>
-    <!-- After submission, the link will lead to the results sheet -->
-    <a id="popupClassroomLink" href="https://docs.google.com/spreadsheets/d/1dOXoMPSdjYWssoPpzHb1xeXp1t_U02CP2itF7IJDCUI/edit?usp=sharing" target="_blank">Open Results Sheet</a>
+    <p>You can now visit Google Classroom to record your work.</p>
+    <!-- After submission, the link will lead to Google Classroom -->
+    <a id="popupClassroomLink" href="https://classroom.google.com/w/NzQxODI2OTY5NTgy/t/all" target="_blank">Open Google Classroom</a>
   </div>
 </div>
 
@@ -375,7 +375,7 @@
 
 <script>
 const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbwqQDX-0yTRV-dSZuDbTOccDgTGmfF20UMBHFSI3N2AyCVY4AV3V4F5fONBMqTUL0JX/exec";
-const CLASSROOM_LINK = "https://docs.google.com/spreadsheets/d/1dOXoMPSdjYWssoPpzHb1xeXp1t_U02CP2itF7IJDCUI/edit?usp=sharing";
+const CLASSROOM_LINK = "https://classroom.google.com/w/NzQxODI2OTY5NTgy/t/all";
 
 // Voice setup for text-to-speech
 const synth = window.speechSynthesis;


### PR DESCRIPTION
## Summary
- after a student submits a quiz, direct them to Google Classroom rather than the results spreadsheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884b1579324832698247c098558cafc